### PR TITLE
Remove import React Code

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import GlobalStyle from "./styles/GlobalStyle";
 import RouterConfig from "./navigation/RouterConfig";
 

--- a/src/components/LinkRoute/LinkRoute.tsx
+++ b/src/components/LinkRoute/LinkRoute.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import * as S from "./style";
 
 interface Props {

--- a/src/navigation/NotFound.tsx
+++ b/src/navigation/NotFound.tsx
@@ -1,5 +1,5 @@
-import React, { FC } from "react";
-import LinkRoute from "../components/LinkRoute/index";
+import { FC } from "react";
+import LinkRoute from "../components/LinkRoute/LinkRoute";
 import { SIGN_IN } from "./CONSTANTS";
 
 const NotFound: FC = () => {


### PR DESCRIPTION
React 17부터 import React from 'react'; 코드를 작성하지 않아도 JSX 문법을 쓸 수 있게 되었으므로 불필요한 코드를 지우도록 한다.