### PR TITLE
Create show profile Thumbnail

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.1.10",
     "@types/jest": "^26.0.15",
     "@types/node": "^12.0.0",
-    "@types/react": "^17.0.0",
+    "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.1.7",
     "@types/styled-components": "^5.1.9",

--- a/src/components/Authentication/SetProfile.tsx
+++ b/src/components/Authentication/SetProfile.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import React, { FC } from "react";
 import styled from "styled-components";
 import DefaultProfileIcon from "../../assets/image/DefaultProfileIcon.png";
 
@@ -12,7 +12,7 @@ const SContainer = styled.div`
   margin: 0 auto;
 `;
 
-const SDefaultProfile = styled.div`
+const SProfileWrapper = styled.div`
   width: 100%;
   height: 7.8vw;
   border-radius: 50%;
@@ -22,23 +22,47 @@ const SDefaultProfile = styled.div`
   align-items: center;
 `;
 
+const SProfileImg = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+`
+
 const SDefaultProfileIcon = styled.img`
   width: 3.1vw;
   height: 3.1vw;
 `;
 
-const SProfileExplanation = styled.p`
+const SProfileFileInputText = styled.label`
   font-size: 1.1vw;
-  color: #8d8d8d;
+  color: #8D8D8D;
+  cursor: pointer;
+`
+
+const SProfileFileInput = styled.input`
+  width: 100%;
+  height: 100%;
+  display: none;
 `;
 
-export const SetProfile: FC = () => {
+interface Props {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  thumbnail: string | undefined;
+}
+
+export const SetProfile: FC<Props> = ({ onChange, thumbnail }) => {
   return (
     <SContainer>
-      <SDefaultProfile>
-        <SDefaultProfileIcon src={DefaultProfileIcon} />
-      </SDefaultProfile>
-      <SProfileExplanation>프로필 설정하기</SProfileExplanation>
+      <SProfileWrapper>
+        {thumbnail ?
+          <SProfileImg src={thumbnail} /> :
+          <SDefaultProfileIcon src={DefaultProfileIcon} />
+        }
+      </SProfileWrapper>
+      <SProfileFileInputText>
+        프로필 설정하기
+        <SProfileFileInput type="file" onChange={onChange} />
+      </SProfileFileInputText>
     </SContainer>
   );
 };

--- a/src/components/Authentication/SetProfile.tsx
+++ b/src/components/Authentication/SetProfile.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import styled from "styled-components";
 import DefaultProfileIcon from "../../assets/image/DefaultProfileIcon.png";
 

--- a/src/pages/RegisterChildren/RegisterChildrenProfile/RegisterChildrenProfileView.tsx
+++ b/src/pages/RegisterChildren/RegisterChildrenProfile/RegisterChildrenProfileView.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import styled from "styled-components";
 import { SetProfile } from "../../../components/Authentication/SetProfile";
 import { SubmitButton } from "../../../components/Authentication/SubmitButton";
@@ -30,10 +30,27 @@ interface Props {
 export const RegisterChildrenProfileView: FC<Props> = ({
   onIncreasePageNum,
 }) => {
+  const [thumbnail, setThumbnail] = useState<string | undefined>();
+  const [profileThumbnail, setProfileThumbnail] = useState<File | null>(null);
+
+  const onChangeProfileImg = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+
+    const reader = new FileReader();
+
+    setProfileThumbnail(e.target.files[0]);
+
+    reader.onload = function (e) {
+      setThumbnail(e.target?.result?.toString());
+    }
+
+    reader.readAsDataURL(e.target.files[0]);
+  }
+
   return (
     <SContainer>
       <SInputFormWrapper>
-        <SetProfile />
+        <SetProfile onChange={onChangeProfileImg} thumbnail={thumbnail} />
       </SInputFormWrapper>
       <SubmitButton text="아이 등록하기" onClick={onIncreasePageNum} />
       <WarningText />

--- a/src/pages/SignUp/SignUpProfile/SignUpProfileView.tsx
+++ b/src/pages/SignUp/SignUpProfile/SignUpProfileView.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import React, { FC, useState } from "react";
 import styled from "styled-components";
 import { InputForm } from "../../../components/Authentication/InputForm";
 import { PagePoint } from "../../../components/Authentication/PagePoint";
@@ -27,11 +27,39 @@ interface Props {
   onIncreasePageNum: () => void;
 }
 
+interface IProfileForm {
+  thumbnail: File | null;
+  name: string;
+}
+
 export const SignUpProfileView: FC<Props> = ({ onIncreasePageNum }) => {
+  const [thumbnail, setThumbnail] = useState<string | undefined>();
+  const [profileForm, setProfileForm] = useState<IProfileForm>({
+    thumbnail: null,
+    name: "",
+  });
+
+  const onChangeProfileImg = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files || !e.target.value) return;
+
+    const reader = new FileReader();
+
+    setProfileForm({
+      ...profileForm,
+      thumbnail: e.target?.files[0],
+    });
+
+    reader.onload = function (e) {
+      setThumbnail(e.target?.result?.toString());
+    }
+
+    reader.readAsDataURL(e.target.files[0]);
+  }
+
   return (
     <SContainer>
       <SInputFormWrapper>
-        <SetProfile />
+        <SetProfile onChange={onChangeProfileImg} thumbnail={thumbnail} />
         <InputForm type="text" title="이름" placeholder="이름을 입력하세요" />
       </SInputFormWrapper>
       <SubmitButton text="회원가입" onClick={onIncreasePageNum} />


### PR DESCRIPTION
프로필 사진 설정 시 미리보기를 화면에 출력해주는 로직을 구현했다.
이유는 모르겠으나 ShaWorld 프로젝트를 할 때와 img src에서 요구하는 매개변수의 타입이 달랐다.
(ShaWorld: string | ArrayBuffer / 육아는 처음이라: string | undefined)
하지만 fileReader.result는 string | ArrayBuffer | null | undefined 타입이기 때문에 뒤에 toString() 메서드를 붙여줌으로써 ArrayBuffer 타입을 string으로 타입 변환하여 type error를 해결했다.