### PR TITLE
Complete Check ID Duplication Logic

### DIFF
--- a/src/hooks/useCase/useSignUpUseCase/useSignUpFormUseCase/index.ts
+++ b/src/hooks/useCase/useSignUpUseCase/useSignUpFormUseCase/index.ts
@@ -1,0 +1,43 @@
+import { useContext } from "react";
+import { SignUpContext } from "../../../../contexts/SignUpContext";
+import { checkIdDuplication } from "../../../../services";
+import { useSignUpForm } from "../../../domain/useSignUp/useSignUpForm";
+
+const useSignUpFormUseCase = () => {
+  const { onIncreasePageNum } = useContext(SignUpContext);
+  const {
+    state: { formData, idError, pwError, pwConfirmError },
+    setState: { setFormData, setIdError, setPwError, setPwConfirmError },
+  } = useSignUpForm();
+
+  const checkIdDuplicationUseCase = () => {
+    checkIdDuplication(formData.id).then(
+      (res) => {
+        alert("이미 사용중인 아이디입니다.");
+        Promise.resolve(res);
+      },
+      (err) => {
+        switch (err.response.status) {
+          case 400:
+            alert("올바르지 않은 형식입니다.");
+            break;
+          case 404:
+            onIncreasePageNum();
+            break;
+          default:
+            break;
+        }
+        setIdError(true);
+        Promise.reject(err);
+      }
+    );
+  };
+
+  return {
+    state: { formData, idError, pwError, pwConfirmError },
+    setState: { setFormData, setIdError, setPwError, setPwConfirmError },
+    useCase: { checkIdDuplicationUseCase },
+  };
+};
+
+export default useSignUpFormUseCase;

--- a/src/pages/SignUp/SignUpForm/SIgnUpFormContainer.tsx
+++ b/src/pages/SignUp/SignUpForm/SIgnUpFormContainer.tsx
@@ -1,14 +1,15 @@
 import { ChangeEvent, FC, useContext } from 'react';
 import { SignUpContext } from '../../../contexts/SignUpContext';
-import { useSignUpForm } from '../../../hooks/domain/useSignUp';
+import useSignUpFormUseCase from '../../../hooks/useCase/useSignUpUseCase/useSignUpFormUseCase';
 import { SignUpFormView } from './SignUpFormView';
 
 export const SignUpFormContainer: FC = () => {
     const {
         state: { formData, idError, pwError, pwConfirmError },
-        setState: { setFormData, setIdError, setPwError, setPwConfirmError }
-    } = useSignUpForm();
-    const { onIncreasePageNum, setContextId, setContextPw } = useContext(SignUpContext);
+        setState: { setFormData, setIdError, setPwError, setPwConfirmError },
+        useCase: { checkIdDuplicationUseCase }
+    } = useSignUpFormUseCase();
+    const { setContextId, setContextPw } = useContext(SignUpContext);
 
     const onChangeFormData = (e: ChangeEvent<HTMLInputElement>) => {
         setFormData({
@@ -21,7 +22,7 @@ export const SignUpFormContainer: FC = () => {
         if (callFormatCheckFuncs()) return;
         setContextId(formData.id);
         setContextPw(formData.pw);
-        onIncreasePageNum();
+        checkIdDuplicationUseCase();
     }
 
     const callFormatCheckFuncs = (): boolean => {

--- a/src/pages/SignUp/SignUpForm/index.ts
+++ b/src/pages/SignUp/SignUpForm/index.ts
@@ -1,1 +1,1 @@
-export { SignUpFormContainer as default } from "./SIgnUpFormContainer";
+export { SignUpFormContainer as default } from "./SignUpFormContainer";

--- a/src/services/CONSTANTS.ts
+++ b/src/services/CONSTANTS.ts
@@ -2,6 +2,8 @@ export const SIGN_UP_SEND_CERTIFY_CODE = (phoneNumber: string) =>
   `/phones/phone-number/${phoneNumber}/certify-code`;
 export const SIGN_UP_GET_CERTIFICATION = (phoneNumber: string) =>
   `/phones/phone-number/${phoneNumber}/certification`;
+export const SIGN_UP_CHECK_ID_DUPLICATION = (id: string) =>
+  `/parents/id/${id}/existence`;
 export const SIGN_UP_CREATE_PARENT_ACCOUNT = () => "/parents";
 
 export const SIGN_IN = () => "/login/parent";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,6 @@
 export { sendCertifyCode } from "./signUp/signUpService";
 export { getCertification } from "./signUp/signUpService";
+export { checkIdDuplication } from "./signUp/signUpService";
 export { createParentAccount } from "./signUp/signUpService";
 
 export { signIn } from "./signIn/signInService";

--- a/src/services/signUp/signUpService.ts
+++ b/src/services/signUp/signUpService.ts
@@ -3,6 +3,7 @@ import {
   SIGN_UP_SEND_CERTIFY_CODE,
   SIGN_UP_GET_CERTIFICATION,
   SIGN_UP_CREATE_PARENT_ACCOUNT,
+  SIGN_UP_CHECK_ID_DUPLICATION,
 } from "../CONSTANTS";
 import { IParentAccountForm, IValidationData } from "./payload";
 
@@ -31,6 +32,20 @@ export const getCertification = async (
       {
         certify_code: parseInt(data.certifyCode),
       }
+    );
+
+    return res.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const checkIdDuplication = async (
+  id: string
+): Promise<IDefaultResponse | undefined> => {
+  try {
+    const res = await request.get<IDefaultResponse>(
+      SIGN_UP_CHECK_ID_DUPLICATION(id)
     );
 
     return res.data;


### PR DESCRIPTION
회원가입 페이지 중 아이디 작성 페이지에서 다음 버튼을 누르면 아이디 중복 확인이 되는 로직을 구현했다.